### PR TITLE
Dd proc name fix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,23 @@ WORKDIR /app
 COPY requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt
 
-COPY . .
+COPY app app
+COPY gunicorn_config.py .
+COPY requirements.txt .
+COPY start.sh .
+COPY wsgi.py .
 RUN chmod +x /app/start.sh
 
 # Inject and install Datadog agent with install only. Start service upon spin up
 RUN apt update && apt install -y curl
-RUN DD_LOGS_ENABLED="true" DD_HOSTNAME="my-host-name" DD_API_KEY="61ffbaddaa97a867b302ff54f5b181d5" DD_SITE="datadoghq.com" DD_INSTALL_ONLY="false"  bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+
+# Broke out DD env for easier management
+ENV DD_LOGS_ENABLED="true"
+ENV DD_APM_ENABLED="true"
+ENV DD_SITE="datadoghq.com"
+ENV DD_INSTALL_ONLY="false" 
+ENV DD_API_KEY="" 
+RUN bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
 RUN cp /etc/datadog-agent/security-agent.yaml.example /etc/datadog-agent/security-agent.yaml
 
 # Copy gunicorn.conf.yaml to Datadog's integrations for log capture
@@ -21,6 +32,10 @@ COPY gunicorn.conf.yaml /etc/datadog-agent/conf.d/gunicorn.d/conf.yaml
 # Send metrics to DogStatsD
 ENV STATSD_HOST="localhost:8125"
 RUN sed -i 's/# logs_enabled: false/logs_enabled: true/' /etc/datadog-agent/datadog.yaml
+
+# Use the container hostname
+RUN sed -i 's/# hostname_fqdn: false/hostname_fqdn: true/' /etc/datadog-agent/datadog.yaml
+RUN sed -i 's/# hostname_trust_uts_namespace: false/hostname_trust_uts_namespace: true/' /etc/datadog-agent/datadog.yaml
 
 # Set logging directory for gunicorn
 ENV ACCESS_LOG="/var/log/gunicorn/access.log"

--- a/gunicorn.conf.yaml
+++ b/gunicorn.conf.yaml
@@ -1,5 +1,5 @@
 init_config:
-
+  service: "EXAMPLE_GUNICORN_APP"
 instances:
     ## @param proc_name - string - required
     ## The name of the gunicorn process. For the following gunicorn server:
@@ -12,12 +12,10 @@ instances:
 logs:
 - type: file
   path: /var/log/gunicorn/access.log
-  service: "EXAMPLE_GUNICORN_APP"
   source: gunicorn
 
 - type: file
   path: /var/log/gunicorn/error.log
-  service: "EXAMPLE_GUNICORN_APP"
   source: gunicorn
   log_processing_rules:
     - type: multi_line

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,5 +1,5 @@
 import os
-
+import json
 from multiprocessing import cpu_count
 
 # gunicorn -c gunicorn_config.py wsgi:app
@@ -17,9 +17,26 @@ workers = (cpu_count() * 2) + 1
 threads = pool_size - safety_net
 worker_class = 'gthread'
 proc_name = "gunicorn"
-default_proc_name = "gunicorn"
+# default_proc_name = "gunicorn"
 timeout = 60
-accesslog = '-'
-errorlog = '-'
+# accesslog = '-'
+# errorlog = '-'
 loglevel = 'debug'
 capture_output = True
+accesslog_var = os.getenv("ACCESS_LOG", "-")
+use_accesslog = accesslog_var or None
+accesslog = use_accesslog
+errorlog_var = os.getenv("ERROR_LOG", "-")
+use_errorlog = errorlog_var or None
+errorlog = use_errorlog
+
+log_data = {
+    "loglevel": loglevel,
+    "workers": workers,
+    "bind": bind,
+    "timeout": timeout,
+    "errorlog": errorlog,
+    "accesslog": accesslog,
+    # Additional, non-gunicorn variables
+}
+print(json.dumps(log_data))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==3.1.0
 gunicorn==23.0.0
+gunicorn[setproctitle]==23.0.0


### PR DESCRIPTION
Root fix is setting of `gunicorn[setproctitle]==23.0.0` in the `requirements.txt`. This is called out in [https://docs.gunicorn.org/en/stable/settings.html#proc-name](https://docs.gunicorn.org/en/stable/settings.html#proc-name) in the second paragraph. You will see this show up initially in the logs live tail and then will start to see the container name show up in the infrastructure section.

**Note**: You will need to add back your API key in the Dockerfile

> This requires that you install the setproctitle module.

### Additional items
- Centralized service name in `gunicorn.conf.yaml`
- Enabled access logs
- Broke out dd env for maintenance
- Turned on hostname for container
